### PR TITLE
Refactor image thumbnail cache into ImageCache component

### DIFF
--- a/common/components/ImageCache.php
+++ b/common/components/ImageCache.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace common\components;
+
+use Yii;
+use yii\base\Component;
+use yii\helpers\FileHelper;
+use yii\imagine\Image;
+
+/**
+ * Builds thumbnail paths under the public cache tree and generates missing files from the store.
+ */
+class ImageCache extends Component
+{
+    /** @var string Filesystem alias or path to originals (relative paths from DB are resolved here). */
+    public $storePath = '@webroot/images/store';
+
+    /** @var string Filesystem alias or path where generated thumbnails are written. */
+    public $cachePath = '@webroot/images/cache';
+
+    /** @var string URL prefix for cached images (no trailing slash). */
+    public $publicBaseUrl = '/images/cache';
+
+    /**
+     * Ensures a cached thumbnail exists and returns its public URL and leaf filename.
+     *
+     * @param string $relativeStorePath Path under the store (e.g. from image.filePath).
+     * @param array $options Optional keys: quality (int), filenamePrefix (string), fallbackSource (absolute path if original is missing).
+     * @return array{url: string, filename: string}
+     */
+    public function getThumbnail(string $relativeStorePath, int $width, int $height, array $options = []): array
+    {
+        $quality = isset($options['quality']) ? (int) $options['quality'] : 90;
+        $filenamePrefix = isset($options['filenamePrefix']) ? (string) $options['filenamePrefix'] : '';
+        $fallbackSource = isset($options['fallbackSource']) ? (string) $options['fallbackSource'] : null;
+
+        $parsed = $this->splitStorePath($relativeStorePath);
+        $leaf = $width . 'x' . $height . '-' . $filenamePrefix . $parsed['basename'];
+        $cacheRelative = ($parsed['dir'] !== '' ? $parsed['dir'] . '/' : '') . $leaf;
+        $fullCache = Yii::getAlias($this->cachePath) . '/' . $cacheRelative;
+
+        if (!is_file($fullCache)) {
+            $primary = Yii::getAlias($this->storePath) . '/' . ltrim(str_replace('\\', '/', $relativeStorePath), '/');
+            $source = is_file($primary) ? $primary : $fallbackSource;
+            if ($source !== null && $source !== '' && is_file($source)) {
+                FileHelper::createDirectory(dirname($fullCache));
+                try {
+                    Image::thumbnail($source, $width, $height)->save($fullCache, ['quality' => $quality]);
+                } catch (\Throwable $e) {
+                    Yii::warning($e->getMessage(), __METHOD__);
+                }
+            }
+        }
+
+        return [
+            'url' => rtrim($this->publicBaseUrl, '/') . '/' . $cacheRelative,
+            'filename' => $leaf,
+        ];
+    }
+
+    /**
+     * @see getThumbnail()
+     */
+    public function getThumbnailUrl(string $relativeStorePath, int $width, int $height, array $options = []): string
+    {
+        return $this->getThumbnail($relativeStorePath, $width, $height, $options)['url'];
+    }
+
+    /**
+     * @return array{dir: string, basename: string}
+     */
+    private function splitStorePath(string $relativeStorePath): array
+    {
+        $normalized = str_replace('\\', '/', $relativeStorePath);
+        $parts = explode('/', $normalized);
+        $basename = (string) array_pop($parts);
+        $dir = implode('/', $parts);
+
+        return ['dir' => $dir, 'basename' => $basename];
+    }
+}

--- a/common/config/main.php
+++ b/common/config/main.php
@@ -47,6 +47,11 @@ return [
         'cache' => [
             'class' => 'yii\caching\FileCache',
         ],
+        'imageCache' => [
+            'class' => 'common\components\ImageCache',
+            'storePath' => dirname(dirname(__DIR__)) . '/frontend/web/images/store',
+            'cachePath' => dirname(dirname(__DIR__)) . '/frontend/web/images/cache',
+        ],
         'user' => [
             //'class' => 'yii\web\User',
 //            'enableRegistration' => false,

--- a/composer.json
+++ b/composer.json
@@ -83,6 +83,7 @@
     },
     "autoload": {
         "psr-4": {
+            "common\\": "common/",
             "pistol88\\shop\\": "common/modules/pistol88/yii2-shop"
         }
     }

--- a/frontend/views/blocks/certs.php
+++ b/frontend/views/blocks/certs.php
@@ -1,48 +1,18 @@
 <?php
 use common\models\Cert;
-use yii\imagine\Image;
-use Imagine\Image\Box;
+use Yii;
 ?>
 <div class="certs gradient-bg">
     <div class="container">
         <div class="owl-three certs__gallery owl-carousel owl-theme">
             <?php foreach(Cert::findAll(['active' => 'yes']) as $item): ?>
                 <?php
-                $width = 421;
-                $height = 562;
                 $imagePath = $item->image->filePath;
-                $path = explode('/', $imagePath);
-                $filename = $width.'x'.$height . '-' . array_pop($path);
-                $pathToImg = implode('/', $path);
-                if(!file_exists(Yii::getAlias('@webroot/images/cache/') . $pathToImg . '/' . $filename)) {
-                    try {
-                        Image::getImagine()->open(Yii::getAlias('@webroot/images/store/') . $imagePath)->
-                        thumbnail(new Box($width, $height))->
-                        save(Yii::getAlias('@webroot/images/cache/') . $pathToImg . '/' . $filename, ['quality' => 90]);
-                    } catch (\Exception $exception) {
-
-                    }
-                }
+                $hrefUrl = Yii::$app->imageCache->getThumbnailUrl($imagePath, 421, 562, ['quality' => 90]);
+                $thumbUrl = Yii::$app->imageCache->getThumbnailUrl($imagePath, 322, 422, ['quality' => 90]);
                 ?>
-                <a href="<?='/images/cache/' . $pathToImg . '/' . $filename?>" rel="fancybox-button" class="lbox" alt="Сертификат" title="Сертификат">
-                    <?php
-                    $width = 322;
-                    $height = 422;
-                    $imagePath = $item->image->filePath;
-                    $path = explode('/', $imagePath);
-                    $filename = $width.'x'.$height . '-' . array_pop($path);
-                    $pathToImg = implode('/', $path);
-                    if(!file_exists(Yii::getAlias('@webroot/images/cache/') . $pathToImg . '/' . $filename)) {
-                        try {
-                            Image::getImagine()->open(Yii::getAlias('@webroot/images/store/') . $imagePath)->
-                            thumbnail(new Box($width, $height))->
-                            save(Yii::getAlias('@webroot/images/cache/') . $pathToImg . '/' . $filename, ['quality' => 90]);
-                        } catch (\Exception $exception) {
-
-                        }
-                    }
-                    ?>
-                    <img class="owl-lazy" data-src="<?='/images/cache/' . $pathToImg . '/' . $filename?>" />
+                <a href="<?= $hrefUrl ?>" rel="fancybox-button" class="lbox" alt="Сертификат" title="Сертификат">
+                    <img class="owl-lazy" data-src="<?= $thumbUrl ?>" />
                 </a>
             <?php endforeach ?>
         </div>

--- a/frontend/views/blocks/main-block.php
+++ b/frontend/views/blocks/main-block.php
@@ -1,7 +1,6 @@
 <?php
-use yii\imagine\Image;
-use Imagine\Image\Box;
 use app\components\Helper;
+use Yii;
 
 $cur = "р.";
 ?>
@@ -16,29 +15,16 @@ $cur = "р.";
                         <div class="main-block-slider-item">
                             <a href="<?= $productUrl ?>" class="main-block__imglink"><?php
                                 $width = 320;
-                                $height = $width * 3 / 4;
+                                $height = (int) ($width * 3 / 4);
                                 $imagePath = $product->image->filePath;
-                                $path = explode('/', $imagePath);
-                                $filename = $width.'x'.$height . '-' . array_pop($path);
-                                $pathToImg = implode('/', $path);
-                                if(!file_exists(Yii::getAlias('@webroot/images/cache/') . $pathToImg . '/' . $filename)) {
-                                    $original = Yii::getAlias('@webroot/images/store/') . $imagePath;
-
-                                    if (!file_exists($original)) {
-                                        $moduleGallery = Yii::$app->getModule('gallery');
-
-                                        $original = Yii::getAlias($moduleGallery->placeHolderPath);
-                                    }
-
-                                    try {
-                                        Image::getImagine()->open($original)->
-                                        thumbnail(new Box($width, $height))->
-                                        save(Yii::getAlias('@webroot/images/cache/') . $pathToImg . '/' . $filename, ['quality' => 90]);
-                                    } catch (\Exception $exception) {
-
-                                    }
-                                }?>
-                                <img src="<?='/images/cache/' . $pathToImg . '/' . $filename?>"
+                                $original = Yii::getAlias('@webroot/images/store/') . $imagePath;
+                                $fallback = is_file($original) ? null : Yii::getAlias(Yii::$app->getModule('gallery')->placeHolderPath);
+                                $imgUrl = Yii::$app->imageCache->getThumbnailUrl($imagePath, $width, $height, [
+                                    'quality' => 90,
+                                    'fallbackSource' => $fallback,
+                                ]);
+                                ?>
+                                <img src="<?= $imgUrl ?>"
                                      class="main-block-12psb"/>
                                 <i class="product-stock">
                                     <?= ($product->available == "yes") ? "В Наличии" : "Под заказ" ?>

--- a/frontend/views/blocks/oboruds.php
+++ b/frontend/views/blocks/oboruds.php
@@ -2,7 +2,7 @@
 use pistol88\shop\models\Category;
 use pistol88\shop\models\Image as PistolImage;
 use pistol88\shop\models\Price;
-use yii\imagine\Image;
+use Yii;
 use yii\helpers\Html;
 
 $title = $products[0]->category->name;
@@ -36,14 +36,12 @@ $title = $products[0]->category->name;
                     $width = 278;
                     $height = 278;
                     $imagePath = $image->filePath;
-                    $path = explode('/', $imagePath);
-                    $filename = $width.'x'.$height . '-thumb-' . array_pop($path);
-                    $pathToImg = implode('/', $path);
-                    if(!file_exists(Yii::getAlias('@webroot/images/cache/') . $pathToImg . '/' . $filename)) {
-                        Image::thumbnail(Yii::getAlias('@webroot/images/store/') . $imagePath, $width, $height)
-                            ->save(Yii::getAlias('@webroot/images/cache/') . $pathToImg . '/' . $filename, ['quality' => 100]);
-                    }?>
-                    <img src="<?='/images/cache/' . $pathToImg . '/' . $filename?>">
+                    $imgUrl = Yii::$app->imageCache->getThumbnailUrl($imagePath, $width, $height, [
+                        'quality' => 100,
+                        'filenamePrefix' => 'thumb-',
+                    ]);
+                    ?>
+                    <img src="<?= $imgUrl ?>">
                 </a>
             </div>
             <div class="oborud__info">

--- a/frontend/views/site/view.php
+++ b/frontend/views/site/view.php
@@ -7,8 +7,7 @@ function hidetab($val)
 
 use pistol88\shop\models\Image as ImagePistol;
 use pistol88\shop\models\Price;
-use yii\imagine\Image;
-use Imagine\Image\Box;
+use Yii;
 use yii\widgets\Breadcrumbs;
 use app\components\Helper;
 use common\models\ProductReview;
@@ -73,19 +72,12 @@ $this->registerMetaTag(['og:title' => $this->title]);
                 <?php foreach ($images as $image) { ?>
                     <div class="tovar__gallery-item"><?php
                         $width = 600;
-                        $height = $width * 3 / 4;
+                        $height = (int) ($width * 3 / 4);
                         $imagePath = $image->filePath;
-                        $path = explode('/', $imagePath);
-                        $filename = $width . 'x' . $height . '-' . array_pop($path);
-                        $pathToImg = implode('/', $path);
-
-                        if (!file_exists(Yii::getAlias('@webroot/images/cache/') . $pathToImg . '/' . $filename)) {
-                            Image::getImagine()->open(Yii::getAlias('@webroot/images/store/') . $imagePath)->
-                            thumbnail(new Box($width, $height))->
-                            save(Yii::getAlias('@webroot/images/cache/') . $pathToImg . '/' . $filename, ['quality' => 100]);
-                        } ?>
-                        <img data-filename="<?= $filename ?>" itemprop="image"
-                             data-src="<?= '/images/cache/' . $pathToImg . '/' . $filename ?>" class="owl-lazy"
+                        $thumb = Yii::$app->imageCache->getThumbnail($imagePath, $width, $height, ['quality' => 100]);
+                        ?>
+                        <img data-filename="<?= $thumb['filename'] ?>" itemprop="image"
+                             data-src="<?= $thumb['url'] ?>" class="owl-lazy"
                              width="374" height="374"/>
                         <i class="product-stock"><?= ($product->available == "yes") ? "В Наличии" : "Под заказ" ?></i>
                     </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Duplicated logic across several views (split path, build cache filename, `file_exists`, open from store, `thumbnail`, `save`, empty catch) is replaced by a single `common\components\ImageCache` application component registered as `Yii::$app->imageCache`.

## Changes

- **New** `ImageCache`: configurable `storePath` / `cachePath`, creates cache directories, uses `yii\imagine\Image::thumbnail`, logs failures via `Yii::warning` instead of silent empty catches.
- **API**: `getThumbnailUrl()` for simple cases; `getThumbnail()` returns `url` + `filename` for views that need the leaf name (product gallery).
- **Views updated**: `main-block.php`, `certs.php`, `oboruds.php`, `site/view.php`.
- **composer.json**: PSR-4 `common\\` → `common/` so the class autoloads (run `composer dump-autoload` after pull if vendor is not refreshed automatically).

## Behaviour preserved

- Cache file naming and URL layout match the previous pattern (`WxH-`, optional `thumb-` prefix for oboruds).
- Promo block still falls back to the gallery module placeholder when the store file is missing.

## Note

PHP/composer were not available in the agent environment; please run `composer dump-autoload` and a quick smoke test of affected pages locally.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83618556-f209-46eb-b423-066f2bffd280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83618556-f209-46eb-b423-066f2bffd280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

